### PR TITLE
Corrected line 17 that causes a NotSerializableException

### DIFF
--- a/src/br/com/androidpro/javaandroid/exercicio4/TestaSerializacao.java
+++ b/src/br/com/androidpro/javaandroid/exercicio4/TestaSerializacao.java
@@ -14,7 +14,7 @@ public class TestaSerializacao {
             // Para Windows utilize o caminho c:\\funcionario.ser
             FileOutputStream fileOut = new FileOutputStream("/home/funcionario.ser");
             ObjectOutputStream out = new ObjectOutputStream (fileOut);
-            out.writeObject(out);
+            out.writeObject(funcionario);
             System.out.println("Serializando...");
             out.close();
             fileOut.close();


### PR DESCRIPTION
Changed the line "out.writeObject(out);"
to "out.writeObject(funcionario);"

OBS.: The code sample in the eBook "Java Essencial para Android" has the same error!